### PR TITLE
修复分页组件前后都出现省略号时页码错误问题

### DIFF
--- a/packages/stdf/components/pagination/Pagination.svelte
+++ b/packages/stdf/components/pagination/Pagination.svelte
@@ -126,11 +126,11 @@
 
 	// 当前页码大于等于 maxShowPage-3 时，不显示前面的省略号
 	// current >= maxShowPage-3, not show pre ellipsis
-	const showPreEllipsis = current > maxShowPage - 2;
+	$: showPreEllipsis = current > maxShowPage - 2;
 
 	// 当前页码小于等于 totalPage - (maxShowPage-3) 时，不显示后面的省略号
 	// current <= totalPage - (maxShowPage-3), not show next ellipsis
-	const showNextEllipsis = current <= maxShowPage - 2 || current <= totalPage - (maxShowPage - 3);
+	$: showNextEllipsis = current <= maxShowPage - 2 || current <= totalPage - (maxShowPage - 3);
 
 	// 当显示前面的省略号时，中间显示的页码数 middleShowPage 个数为 maxShowPage - 4，内容为当前页码（maxShowPage为5）或者当前页码和前后一项（maxShowPage为7）或者当前页码和前后两项（maxShowPage为9）
 	// when show pre ellipsis, middleShowPage length is maxShowPage - 4, content is current page (maxShowPage is 5) or current page and pre/next one (maxShowPage is 7) or current page and pre/next two (maxShowPage is 9)


### PR DESCRIPTION
当页码两端均显示省略号时，页码显示错误，经检查是否显示前后省略号应该是根据页码与显示个数实时改变的，修改这两个变量为【派生】变量。
<img width="406" alt="image" src="https://github.com/any-tdf/stdf/assets/31542814/998df391-57ce-47bb-9ebb-755e9dc331b8">
 