### PR TITLE
[stdf]Add base TypeScript support

### DIFF
--- a/packages/stdf/components/index.d.ts
+++ b/packages/stdf/components/index.d.ts
@@ -1,0 +1,93 @@
+import ActionSheet from './actionSheet/ActionSheet.svelte';
+import AsyncPicker from './asyncPicker/AsyncPicker.svelte';
+import Avatar from './avatar/Avatar.svelte';
+import Avatars from './avatar/Avatars.svelte';
+import Badge from './badge/Badge.svelte';
+import BottomSheet from './bottomSheet/BottomSheet.svelte';
+import Button from './button/Button.svelte';
+import Calendar from './calendar/Calendar.svelte';
+import Cell from './cell/Cell.svelte';
+import CellGroup from './cell/CellGroup.svelte';
+import Checkbox from './checkbox/Checkbox.svelte';
+import CheckboxGroup from './checkbox/CheckboxGroup.svelte';
+import Dialog from './dialog/Dialog.svelte';
+import Divider from './divider/Divider.svelte';
+import Grid from './grids/Grid.svelte';
+import Grids from './grids/Grids.svelte';
+import Icon from './icon/Icon.svelte';
+import IndexBar from './indexBar/IndexBar.svelte';
+import Input from './input/Input.svelte';
+import Loading from './loading/Loading.svelte';
+import Mask from './mask/Mask.svelte';
+import Modal from './modal/Modal.svelte';
+import NavBar from './navBar/NavBar.svelte';
+import NoticeBar from './noticeBar/NoticeBar.svelte';
+import NumKeyboard from './numKeyboard/NumKeyboard.svelte';
+import Pagination from './pagination/Pagination.svelte';
+import Picker from './picker/Picker.svelte';
+import Placeholder from './placeholder/Placeholder.svelte';
+import Popup from './popup/Popup.svelte';
+import Progress from './progress/Progress.svelte';
+import ProgressLoop from './progressLoop/ProgressLoop.svelte';
+import Radio from './radio/Radio.svelte';
+import RadioGroup from './radio/RadioGroup.svelte';
+import Rate from './rate/Rate.svelte';
+import Skeleton from './skeleton/Skeleton.svelte';
+import Slider from './slider/Slider.svelte';
+import Steps from './steps/Steps.svelte';
+import Switch from './switch/Switch.svelte';
+import Swiper from './swiper/Swiper.svelte';
+import Tab from './tabs/Tab.svelte';
+import TabBar from './tabBar/TabBar.svelte';
+import TabContent from './tabs/TabContent.svelte';
+import Tabs from './tabs/Tabs.svelte';
+import TimePicker from './timePicker/TimePicker.svelte';
+import Toast from './toast/Toast.svelte';
+
+export {
+	ActionSheet,
+	AsyncPicker,
+	Avatar,
+	Avatars,
+	Badge,
+	BottomSheet,
+	Button,
+	Calendar,
+	Cell,
+	CellGroup,
+	Checkbox,
+	CheckboxGroup,
+	Dialog,
+	Divider,
+	Grid,
+	Grids,
+	Icon,
+	IndexBar,
+	Input,
+	Loading,
+	Mask,
+	Modal,
+	NavBar,
+	NoticeBar,
+	NumKeyboard,
+	Pagination,
+	Picker,
+	Placeholder,
+	Popup,
+	Progress,
+	ProgressLoop,
+	Radio,
+	RadioGroup,
+	Rate,
+	Skeleton,
+	Slider,
+	Steps,
+	Switch,
+	Swiper,
+	Tab,
+	TabBar,
+	TabContent,
+	Tabs,
+	TimePicker,
+	Toast,
+};


### PR DESCRIPTION
是的, 简直像魔法一样, 只要将 `index.js` 复制一份到 `index.d.ts` 就可以获得 TypeScript 代码提示

其实是因为代码库质量很好, 所以才可以做到这样的效果
