### PR TITLE
fix: Allow passing of the `type` property to `<Button/>`

### DIFF
--- a/docs/mds/components/button/api.md
+++ b/docs/mds/components/button/api.md
@@ -19,7 +19,7 @@
 | icon            | [`Icon`](https://stdf.design/components?nav=icon&tab=1)\|`null`             | `null`    | N    | 图标参数。                     |
 | loading         | [`Loading`](https://stdf.design/components?nav=loading&tab=1)\|`null`       | `null`    | N    | 加载参数。                     |
 | disabledLoading | `boolean`                                                                     | `false`   | N    | 加载时是否禁用。               |
-| type            | `'button'\|'reset'\|'submit'\|'menu'`                                                | `button`  | N        | button 的类型。               |
+| type            | `'button'\|'reset'\|'submit'`                                                | `button`  | N        | button 的类型。               |
 
 ## Button Events
 

--- a/docs/mds/components/button/api.md
+++ b/docs/mds/components/button/api.md
@@ -19,6 +19,7 @@
 | icon            | [`Icon`](https://stdf.design/components?nav=icon&tab=1)\|`null`             | `null`    | N    | 图标参数。                     |
 | loading         | [`Loading`](https://stdf.design/components?nav=loading&tab=1)\|`null`       | `null`    | N    | 加载参数。                     |
 | disabledLoading | `boolean`                                                                     | `false`   | N    | 加载时是否禁用。               |
+| type            | `'button'\|'reset'\|'submit'\|'menu'`                                                | `button`  | N        | button 的类型。               |
 
 ## Button Events
 

--- a/docs/mds/components/button/api_en.md
+++ b/docs/mds/components/button/api_en.md
@@ -16,9 +16,10 @@
 | customSize      | `boolean`                                                                     | `false`   | N        | Whether to use custom size.                      |
 | customWidth     | `number`                                                                      | `0`       | N        | Custom width.                                    |
 | customHeight    | `number`                                                                      | `0`       | N        | Custom height.                                   |
-| icon            | [`Icon`](https://stdf.design/components?nav=icon&tab=1)\|`null`             | `null`    | N        | Icon props.                                      |
-| loading         | [`Loading`](https://stdf.design/components?nav=loading&tab=1)\|`null`       | `null`    | N        | Loading props.                                   |
+| icon            | [`Icon`](https://stdf.design/components?nav=icon&tab=1)\|`null`               | `null`    | N        | Icon props.                                      |
+| loading         | [`Loading`](https://stdf.design/components?nav=loading&tab=1)\|`null`         | `null`    | N        | Loading props.                                   |
 | disabledLoading | `boolean`                                                                     | `false`   | N        | Whether to disable when loading.                 |
+| type            | `'button'\|'reset'\|'submit'\|'menu'`                                                 | `button`  | N        | The default behavior of the button               |
 
 ## Button Events
 

--- a/docs/mds/components/button/api_en.md
+++ b/docs/mds/components/button/api_en.md
@@ -19,7 +19,7 @@
 | icon            | [`Icon`](https://stdf.design/components?nav=icon&tab=1)\|`null`               | `null`    | N        | Icon props.                                      |
 | loading         | [`Loading`](https://stdf.design/components?nav=loading&tab=1)\|`null`         | `null`    | N        | Loading props.                                   |
 | disabledLoading | `boolean`                                                                     | `false`   | N        | Whether to disable when loading.                 |
-| type            | `'button'\|'reset'\|'submit'\|'menu'`                                                 | `button`  | N        | The default behavior of the button               |
+| type            | `'button'\|'reset'\|'submit'`                                                 | `button`  | N        | The default behavior of the button               |
 
 ## Button Events
 

--- a/packages/stdf/src/lib/components/button/Button.svelte
+++ b/packages/stdf/src/lib/components/button/Button.svelte
@@ -21,6 +21,7 @@
 		icon = null,
 		loading = null,
 		disabledLoading = true,
+		type = 'button',
 		children,
 		onclick
 	}: ButtonProps = $props();
@@ -87,6 +88,7 @@
 			: ''}"
 		disabled={innerDisabled}
 		style={customSize ? `width:${customWidth}px;height:${customHeight}px;padding:0;` : ''}
+		{type}
 	>
 		{#if loading}
 			<Loading {...loading} />

--- a/packages/stdf/src/lib/types/index.ts
+++ b/packages/stdf/src/lib/types/index.ts
@@ -125,7 +125,7 @@ export type ButtonProps = {
 	icon?: IconProps | null;
 	loading?: LoadingProps | null;
 	disabledLoading?: boolean;
-	type?: 'submit' | 'reset' | 'button' | 'menu';
+	type?: 'submit' | 'reset' | 'button';
 	children?: Snippet;
 	onclick?: () => void;
 };

--- a/packages/stdf/src/lib/types/index.ts
+++ b/packages/stdf/src/lib/types/index.ts
@@ -125,6 +125,7 @@ export type ButtonProps = {
 	icon?: IconProps | null;
 	loading?: LoadingProps | null;
 	disabledLoading?: boolean;
+	type?: 'submit' | 'reset' | 'button' | 'menu';
 	children?: Snippet;
 	onclick?: () => void;
 };


### PR DESCRIPTION
Adds the `type` property ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#type)) to the button component to allow it to be used for form submissions and other non-default behaviors.
