### PR TITLE
Fix Grid.svelte Typos of colObj

### DIFF
--- a/packages/stdf/src/lib/components/grids/Grid.svelte
+++ b/packages/stdf/src/lib/components/grids/Grid.svelte
@@ -19,9 +19,9 @@
 		'7': ' col-span-7',
 		'8': ' col-span-8',
 		'9': ' col-span-9',
-		'10': ' cols-span-10',
-		'11': ' cols-span-11',
-		'12': ' cols-span-12'
+		'10': ' col-span-10',
+		'11': ' col-span-11',
+		'12': ' col-span-12'
 	};
 </script>
 


### PR DESCRIPTION
Fixed typos (3)

```
'10': ' cols-span-10',
'11': ' cols-span-11',
'12': ' cols-span-12'
```

should be 
```
'10': ' col-span-10',
'11': ' col-span-11',
'12': ' col-span-12'
```

Before submitting a pull request, please read the [contributing guide](https://stdf.design/guide/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://stdf.design/guide/contribution)。
